### PR TITLE
chore: correct text to Text.tracking() from Text.baselineOffset()

### DIFF
--- a/docs/elements/Text/index.mdx
+++ b/docs/elements/Text/index.mdx
@@ -162,7 +162,7 @@ Letter-spacing, including the separation of ligatures. Supercedes `kerning` if b
     func tracking(_ tracking: CGFloat) -> Text
 */
 VStack(alignment: .trailing, spacing: 10) {
-    Text("Text.baselineOffset()")
+    Text("Text.tracking()")
         .bold()
         .padding([.vertical])
     


### PR DESCRIPTION
As image preview has the updated text